### PR TITLE
Support Linux ARM32SF and ARM32HF variants.

### DIFF
--- a/src/funtest/features/download.feature
+++ b/src/funtest/features/download.feature
@@ -11,7 +11,9 @@ Feature: Download a Candidate Version
       | MAC_ARM64      | /download/java/11.0.9-adpt/darwinarm64     | DarwinARM64    |
       | LINUX_64       | /download/java/11.0.9-adpt/linuxx64        | LinuxX64       |
       | LINUX_32       | /download/java/11.0.9-adpt/linuxx32        | LinuxX32       |
-      | LINUX_ARM32    | /download/java/11.0.9-adpt/linuxarm32      | LinuxARM32     |
+      | LINUX_ARM32SF  | /download/java/11.0.9-adpt/linuxarm32sf    | LinuxARM32SF   |
+      | LINUX_ARM32HF  | /download/java/11.0.9-adpt/linuxarm32hf    | LinuxARM32HF   |
+      | LINUX_ARM64    | /download/java/11.0.9-adpt/linuxarm64      | LinuxARM64   |
       | WINDOWS_64     | /download/java/11.0.9-adpt/msys_nt-10.0    | WindowsX64     |
       | WINDOWS_64     | /download/java/11.0.9-adpt/mingw64_nt-10.0 | WindowsX64     |
       | WINDOWS_64     | /download/java/11.0.9-adpt/cygwin_nt-10.0  | WindowsX64     |

--- a/src/main/java/io/sdkman/broker/download/Platform.java
+++ b/src/main/java/io/sdkman/broker/download/Platform.java
@@ -8,7 +8,8 @@ import static java.util.Arrays.stream;
 
 public enum Platform {
     FREE_BSD(newArrayList("FreeBSD")),
-    LINUX_ARM32(newArrayList("LinuxARM32")),
+    LINUX_ARM32SF(newArrayList("LinuxARM32SF")),
+    LINUX_ARM32HF(newArrayList("LinuxARM32HF")),
     LINUX_ARM64(newArrayList("LinuxARM64")),
     LINUX_32(newArrayList("LinuxX32", "Linux32")),
     LINUX_64(newArrayList("LinuxX64", "Linux64", "Linux")),

--- a/src/test/groovy/io/sdkman/broker/download/PlatformSpec.groovy
+++ b/src/test/groovy/io/sdkman/broker/download/PlatformSpec.groovy
@@ -20,7 +20,8 @@ class PlatformSpec extends Specification {
         "LinuxX32"            | Platform.LINUX_32
         "Linux32"             | Platform.LINUX_32
         "LinuxARM64"          | Platform.LINUX_ARM64
-        "LinuxARM32"          | Platform.LINUX_ARM32
+        "LinuxARM32SF"        | Platform.LINUX_ARM32SF
+        "LinuxARM32HF"        | Platform.LINUX_ARM32HF
 
         "Darwin"              | Platform.MAC_OSX
         "DarwinX64"           | Platform.MAC_OSX


### PR DESCRIPTION
The following new architectures are now supported:

* `LINUX_ARM32SF` (soft float 32 bit ARM)
* `LINUX_ARM32HF` (hard float 32 bit ARM)

The following unused architecture was removed:

* `LINUX_ARM32`
