### PR TITLE
Native binary download endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile ratpack.dependency("guice")
   compile "org.mongodb:mongo-java-driver:3.2.2"
   compile "org.slf4j:slf4j-simple:1.7.5"
-  compile "com.github.sdkman:sdkman-persistent-model:1.1.0"
+  compile "com.github.sdkman:sdkman-persistent-model:1.1.1"
 
   testCompile "org.codehaus.groovy:groovy-all:2.4.19"
   testCompile "org.spockframework:spock-core:1.1-groovy-2.4"

--- a/src/funtest/features/native.feature
+++ b/src/funtest/features/native.feature
@@ -13,3 +13,11 @@ Feature: Native SDKMAN binaries
     | LinuxX64    | LINUX_64      | 0.1.0   | /download/native/install/0.1.0/linuxx64      | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-x86_64-unknown-linux-gnu.zip  |
     | LinuxARM64  | LINUX_ARM64   | 0.1.0   | /download/native/install/0.1.0/linuxarm64    | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-aarch64-unknown-linux-gnu.zip |
     | WindowsX64  | WINDOWS_64    | 0.1.0   | /download/native/install/0.1.0/cygwin_nt-6.1 | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-x86_64-pc-windows-msvc.zip    |
+
+  Scenario: Return a NOT_FOUND status for an unknown platform
+    When a download request is made on "/download/native/install/0.1.0/unknown"
+    Then the service response status is 404
+
+  Scenario: Return a NOT_FOUND status for a unsupported distribution
+    When a download request is made on "/download/native/install/0.1.0/linuxarm32sf"
+    Then the service response status is 404

--- a/src/funtest/features/native.feature
+++ b/src/funtest/features/native.feature
@@ -1,0 +1,15 @@
+Feature: Native SDKMAN binaries
+
+  Scenario Outline: Download the native binary resource for SDKMAN installation and selfupdate
+    Given a native "<distribution>" binary resource for SDKMAN "<version>" is hosted at "<resolved_url>"
+    When a download request is made on "<broker_uri>"
+    Then the service response status is 302
+    And a redirect to "<resolved_url>" is returned
+    And an audit entry for sdkman_native <version> <distribution> is recorded for <platform>
+    Examples:
+    | platform    | distribution  | version | broker_uri                                   | resolved_url                                                                                                               |
+    | DarwinX64   | MAC_OSX       | 0.1.0   | /download/native/install/0.1.0/darwinx64     | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-x86_64-apple-darwin.zip       |
+    | DarwinARM64 | MAC_ARM64     | 0.1.0   | /download/native/install/0.1.0/darwinarm64   | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-aarch64-apple-darwin.zip      |
+    | LinuxX64    | LINUX_64      | 0.1.0   | /download/native/install/0.1.0/linuxx64      | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-x86_64-unknown-linux-gnu.zip  |
+    | LinuxARM64  | LINUX_ARM64   | 0.1.0   | /download/native/install/0.1.0/linuxarm64    | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-aarch64-unknown-linux-gnu.zip |
+    | WindowsX64  | WINDOWS_64    | 0.1.0   | /download/native/install/0.1.0/cygwin_nt-6.1 | https://github.com/sdkman/sdkman-cli-native/releases/download/v0.1.0/sdkman-cli-native-0.1.0-x86_64-pc-windows-msvc.zip    |

--- a/src/funtest/features/resource.feature
+++ b/src/funtest/features/resource.feature
@@ -1,13 +1,13 @@
 Feature: Resource
 
   Scenario: Download the stable binary resource for SDKMAN installation and selfupdate
-    Given a binary resource for "SDKMAN 5.5.11" is hosted at "https://github.com/sdkman/sdkman-cli/releases/download/5.5.11/sdkman-cli-5.5.11.zip"
+    Given a binary resource for SDKMAN "5.5.11" is hosted at "https://github.com/sdkman/sdkman-cli/releases/download/5.5.11/sdkman-cli-5.5.11.zip"
     When a download request is made on "/download/sdkman/install/5.5.11/darwin"
     Then a redirect to "https://github.com/sdkman/sdkman-cli/releases/download/5.5.11/sdkman-cli-5.5.11.zip" is returned
     And an audit entry for sdkman 5.5.11 UNIVERSAL is recorded for DarwinX64
 
   Scenario: Download the beta binary resource for SDKMAN installation and selfupdate
-    Given a binary resource for "SDKMAN latest+abcdef" is hosted at "https://github.com/sdkman/sdkman-cli/releases/download/latest/sdkman-cli-latest+abcdef.zip"
+    Given a binary resource for SDKMAN "latest+abcdef" is hosted at "https://github.com/sdkman/sdkman-cli/releases/download/latest/sdkman-cli-latest+abcdef.zip"
     When a download request is made on "/download/sdkman/install/latest+abcdef/darwin"
     Then a redirect to "https://github.com/sdkman/sdkman-cli/releases/download/latest/sdkman-cli-latest+abcdef.zip" is returned
     And an audit entry for sdkman latest+abcdef UNIVERSAL is recorded for DarwinX64

--- a/src/funtest/groovy/steps/rest.groovy
+++ b/src/funtest/groovy/steps/rest.groovy
@@ -8,6 +8,11 @@ And(~/^a binary resource for SDKMAN "(.*)" is hosted at "(.*)"$/) { String name,
     //nothing to do
 }
 
+And(~/^a native "(.*)" binary resource for SDKMAN "(.*)" is hosted at "(.*)"$/) {
+    String platform, String name, String url ->
+        //nothing to do
+}
+
 And(~/^a download request is made on "(.*)"$/) { String path ->
     try {
         response = httpClient.get(path: path, followRedirects: false)

--- a/src/funtest/groovy/steps/rest.groovy
+++ b/src/funtest/groovy/steps/rest.groovy
@@ -4,7 +4,7 @@ import wslite.rest.RESTClientException
 
 import static io.cucumber.groovy.EN.And
 
-And(~/^a binary resource for "(.*)" is hosted at "(.*)"$/) { String name, String url ->
+And(~/^a binary resource for SDKMAN "(.*)" is hosted at "(.*)"$/) { String name, String url ->
     //nothing to do
 }
 

--- a/src/main/java/io/sdkman/broker/Main.java
+++ b/src/main/java/io/sdkman/broker/Main.java
@@ -7,6 +7,8 @@ import io.sdkman.broker.binary.BinaryVersionHandler;
 import io.sdkman.broker.db.MongoConfig;
 import io.sdkman.broker.db.MongoProvider;
 import io.sdkman.broker.download.CandidateDownloadHandler;
+import io.sdkman.broker.rust.NativeBinaryDownloadConfig;
+import io.sdkman.broker.rust.NativeBinaryDownloadHandler;
 import io.sdkman.broker.version.VersionRepo;
 import io.sdkman.broker.health.MongoHealthCheck;
 import io.sdkman.broker.version.VersionConfig;
@@ -24,11 +26,13 @@ public class Main {
                 .serverConfig(c -> c
                         .props(asByteSource(getResource("version.properties")))
                         .props(asByteSource(getResource("binary.properties")))
+                        .props(asByteSource(getResource("native_binary.properties")))
                         .env()
                         .sysProps()
                         .require("/broker", VersionConfig.class)
                         .require("/mongo", MongoConfig.class)
-                        .require("/binary", BinaryDownloadConfig.class))
+                        .require("/binary", BinaryDownloadConfig.class)
+                        .require("/native", NativeBinaryDownloadConfig.class))
                 .registry(Guice.registry(g -> g
                         .bind(MongoProvider.class)
                         .bind(MongoHealthCheck.class)
@@ -38,12 +42,14 @@ public class Main {
                         .bind(VersionRepo.class)
                         .bind(CandidateDownloadHandler.class)
                         .bind(BinaryVersionHandler.class)
-                        .bind(BinaryDownloadHandler.class)))
+                        .bind(BinaryDownloadHandler.class)
+                        .bind(NativeBinaryDownloadHandler.class)))
                 .handlers(chain -> chain
                         .get("health/:name?", HealthCheckHandler.class)
                         .get("version", VersionHandler.class)
                         .get("download/sdkman/version/:versionType", BinaryVersionHandler.class)
                         .get("download/sdkman/:command/:version/:platform", BinaryDownloadHandler.class)
+                        .get("download/native/:command/:version/:platform", NativeBinaryDownloadHandler.class)
                         .get("download/:candidate/:version/:platform", CandidateDownloadHandler.class)
                         .get("download/:candidate/:version", CandidateDownloadHandler.class)));
     }

--- a/src/main/java/io/sdkman/broker/NativeTarget.java
+++ b/src/main/java/io/sdkman/broker/NativeTarget.java
@@ -1,0 +1,46 @@
+package io.sdkman.broker;
+
+import io.sdkman.broker.download.Platform;
+
+import java.util.Optional;
+
+public enum NativeTarget {
+    LINUX_64("x86_64-unknown-linux-gnu", Platform.LINUX_64),
+    LINUX_ARM64("aarch64-unknown-linux-gnu", Platform.LINUX_ARM64),
+    MAC_OSX("x86_64-apple-darwin", Platform.MAC_OSX),
+    MAC_ARM64("aarch64-apple-darwin", Platform.MAC_ARM64),
+    WINDOWS_64("x86_64-pc-windows-msvc", Platform.WINDOWS_64);
+
+    private final String triple;
+    private final Platform platform;
+
+    NativeTarget(String triple, Platform platform) {
+        this.triple = triple;
+        this.platform = platform;
+    }
+
+    public static Optional<NativeTarget> of(Platform platform) {
+        switch (platform) {
+            case LINUX_64:
+                return Optional.of(LINUX_64);
+            case LINUX_ARM64:
+                return Optional.of(LINUX_ARM64);
+            case MAC_OSX:
+                return Optional.of(MAC_OSX);
+            case MAC_ARM64:
+                return Optional.of(MAC_ARM64);
+            case WINDOWS_64:
+                return Optional.of(WINDOWS_64);
+            default:
+                return Optional.empty();
+        }
+    }
+
+    public String getTriple() {
+        return triple;
+    }
+
+    public Platform getPlatform() {
+        return platform;
+    }
+}

--- a/src/main/java/io/sdkman/broker/app/AppRepo.java
+++ b/src/main/java/io/sdkman/broker/app/AppRepo.java
@@ -20,6 +20,7 @@ public class AppRepo {
     private static final String ALIVE_FIELD_VALUE = "OK";
     private static final String STABLE_VERSION_FIELD_NAME = "stableCliVersion";
     private static final String BETA_VERSION_FIELD_NAME = "betaCliVersion";
+    private static final String STABLE_NATIVE_VERSION_FIELD_NAME = "stableNativeCliVersion";
 
     private final static Logger LOG = LoggerFactory.getLogger(AppRepo.class);
 
@@ -55,6 +56,8 @@ public class AppRepo {
         switch (typeIdentifier) {
             case "stable":
                 return STABLE_VERSION_FIELD_NAME;
+            case "stable_native":
+                return STABLE_NATIVE_VERSION_FIELD_NAME;
             case "beta":
                 return BETA_VERSION_FIELD_NAME;
             default:

--- a/src/main/java/io/sdkman/broker/binary/BinaryDownloadHandler.java
+++ b/src/main/java/io/sdkman/broker/binary/BinaryDownloadHandler.java
@@ -7,12 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
-import ratpack.http.Headers;
-import ratpack.http.Request;
-import ratpack.path.PathTokens;
 
 import javax.inject.Inject;
-import java.util.Optional;
 
 public class BinaryDownloadHandler implements Handler {
 
@@ -28,7 +24,7 @@ public class BinaryDownloadHandler implements Handler {
     }
 
     @Override
-    public void handle(Context ctx) throws Exception {
+    public void handle(Context ctx) {
         RequestDetails.of(ctx).ifPresentOrElse(details -> {
             logger.info("Received download request for: " + details);
             record(details, inferPlatform(details.getPlatform()));
@@ -53,84 +49,5 @@ public class BinaryDownloadHandler implements Handler {
                 AuditEntry.of(
                         details.getCommand(), "sdkman", details.getVersion(), details.getHost(),
                         details.getAgent(), platform, "UNIVERSAL"));
-    }
-
-    public static class RequestDetails {
-
-        private static final String COMMAND_TOKEN_NAME = "command";
-        private static final String VERSION_TOKEN_NAME = "version";
-        private static final String PLATFORM_TOKEN_NAME = "platform";
-        private static final String HOST_HEADER_NAME = "X-Real-IP";
-        private static final String AGENT_HEADER_NAME = "user-agent";
-
-        private final String command;
-        private final String version;
-        private final String platform;
-        private final String host;
-        private final String agent;
-
-        private RequestDetails(String command, String version, String platform, String host, String agent) {
-            this.command = command;
-            this.version = version;
-            this.platform = platform;
-            this.host = host;
-            this.agent = agent;
-        }
-
-        public static Optional<RequestDetails> of(Context ctx) {
-            Request request = ctx.getRequest();
-            Headers headers = request.getHeaders();
-
-            if (isValidRequest(ctx)) {
-                PathTokens tokens = ctx.getAllPathTokens();
-                return Optional.of(
-                        new RequestDetails(
-                                tokens.get(COMMAND_TOKEN_NAME),
-                                tokens.get(VERSION_TOKEN_NAME),
-                                tokens.get(PLATFORM_TOKEN_NAME),
-                                headers.get(HOST_HEADER_NAME),
-                                headers.get(AGENT_HEADER_NAME)));
-            } else {
-                return Optional.empty();
-            }
-        }
-
-        private static boolean isValidRequest(Context ctx) {
-            PathTokens tokens = ctx.getAllPathTokens();
-            return tokens.get(COMMAND_TOKEN_NAME) != null
-                    && tokens.get(VERSION_TOKEN_NAME) != null
-                    && tokens.get(PLATFORM_TOKEN_NAME) != null;
-        }
-
-        public String getCommand() {
-            return command;
-        }
-
-        public String getVersion() {
-            return version;
-        }
-
-        public String getPlatform() {
-            return platform;
-        }
-
-        public String getHost() {
-            return host;
-        }
-
-        public String getAgent() {
-            return agent;
-        }
-
-        @Override
-        public String toString() {
-            return "RequestDetails{" +
-                    "command='" + command + '\'' +
-                    ", version='" + version + '\'' +
-                    ", platform='" + platform + '\'' +
-                    ", host='" + host + '\'' +
-                    ", agent='" + agent + '\'' +
-                    '}';
-        }
     }
 }

--- a/src/main/java/io/sdkman/broker/binary/BinaryVersionHandler.java
+++ b/src/main/java/io/sdkman/broker/binary/BinaryVersionHandler.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public class BinaryVersionHandler implements Handler {
 
-    private static final String VERSION_TYPE_TOKEN = "versionType";
+    private static final String VERSION_TYPE_PATH_TOKEN = "versionType";
 
     private static final Logger logger = LoggerFactory.getLogger(BinaryDownloadHandler.class);
 
@@ -24,8 +24,8 @@ public class BinaryVersionHandler implements Handler {
 
     @Override
     public void handle(Context ctx) throws Exception {
-        logger.info("Received request for SDKMAN binary: {}", ctx.getPathTokens().get(VERSION_TYPE_TOKEN));
-        Optional.ofNullable(ctx.getPathTokens().get(VERSION_TYPE_TOKEN))
+        logger.info("Received request for SDKMAN binary: {}", ctx.getPathTokens().get(VERSION_TYPE_PATH_TOKEN));
+        Optional.ofNullable(ctx.getPathTokens().get(VERSION_TYPE_PATH_TOKEN))
                 .ifPresentOrElse(versionType ->
                                 appRepo.findVersion(versionType).then(version ->
                                         Optional.ofNullable(version)

--- a/src/main/java/io/sdkman/broker/binary/RequestDetails.java
+++ b/src/main/java/io/sdkman/broker/binary/RequestDetails.java
@@ -1,0 +1,87 @@
+package io.sdkman.broker.binary;
+
+import ratpack.handling.Context;
+import ratpack.http.Headers;
+import ratpack.http.Request;
+import ratpack.path.PathTokens;
+
+import java.util.Optional;
+
+public class RequestDetails {
+
+    private static final String COMMAND_PATH_TOKEN_NAME = "command";
+    private static final String VERSION_PATH_TOKEN_NAME = "version";
+    private static final String PLATFORM_PATH_TOKEN_NAME = "platform";
+    private static final String HOST_HEADER_NAME = "X-Real-IP";
+    private static final String AGENT_HEADER_NAME = "user-agent";
+
+    private final String command;
+    private final String version;
+    private final String platform;
+    private final String host;
+    private final String agent;
+
+    private RequestDetails(String command, String version, String platform, String host, String agent) {
+        this.command = command;
+        this.version = version;
+        this.platform = platform;
+        this.host = host;
+        this.agent = agent;
+    }
+
+    public static Optional<RequestDetails> of(Context ctx) {
+        Request request = ctx.getRequest();
+        Headers headers = request.getHeaders();
+
+        if (isValidRequest(ctx)) {
+            PathTokens tokens = ctx.getAllPathTokens();
+            return Optional.of(
+                    new RequestDetails(
+                            tokens.get(COMMAND_PATH_TOKEN_NAME),
+                            tokens.get(VERSION_PATH_TOKEN_NAME),
+                            tokens.get(PLATFORM_PATH_TOKEN_NAME),
+                            headers.get(HOST_HEADER_NAME),
+                            headers.get(AGENT_HEADER_NAME)));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isValidRequest(Context ctx) {
+        PathTokens tokens = ctx.getAllPathTokens();
+        return tokens.get(COMMAND_PATH_TOKEN_NAME) != null
+                && tokens.get(VERSION_PATH_TOKEN_NAME) != null
+                && tokens.get(PLATFORM_PATH_TOKEN_NAME) != null;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getAgent() {
+        return agent;
+    }
+
+    @Override
+    public String toString() {
+        return "RequestDetails{" +
+                "command='" + command + '\'' +
+                ", version='" + version + '\'' +
+                ", platform='" + platform + '\'' +
+                ", host='" + host + '\'' +
+                ", agent='" + agent + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/io/sdkman/broker/rust/NativeBinaryDownloadConfig.java
+++ b/src/main/java/io/sdkman/broker/rust/NativeBinaryDownloadConfig.java
@@ -1,0 +1,24 @@
+package io.sdkman.broker.rust;
+
+public class NativeBinaryDownloadConfig {
+    private final String protocol = null;
+    private final String host = null;
+    private final String uri = null;
+    private final String name = null;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/io/sdkman/broker/rust/NativeBinaryDownloadHandler.java
+++ b/src/main/java/io/sdkman/broker/rust/NativeBinaryDownloadHandler.java
@@ -1,0 +1,52 @@
+package io.sdkman.broker.rust;
+
+import io.sdkman.broker.NativeTarget;
+import io.sdkman.broker.audit.AuditEntry;
+import io.sdkman.broker.audit.AuditRepo;
+import io.sdkman.broker.binary.RequestDetails;
+import io.sdkman.broker.download.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+
+import javax.inject.Inject;
+
+import static java.lang.String.format;
+
+public class NativeBinaryDownloadHandler implements Handler {
+
+    private static final Logger logger = LoggerFactory.getLogger(NativeBinaryDownloadHandler.class);
+
+    private final NativeBinaryDownloadConfig config;
+    private final AuditRepo auditRepo;
+
+    @Inject
+    public NativeBinaryDownloadHandler(NativeBinaryDownloadConfig config, AuditRepo auditRepo) {
+        this.config = config;
+        this.auditRepo = auditRepo;
+    }
+
+    @Override
+    public void handle(Context ctx) throws Exception {
+        RequestDetails.of(ctx).ifPresentOrElse(details -> {
+            logger.info("Received native download request for: " + details);
+            String version = details.getVersion();
+            Platform.of(details.getPlatform()).ifPresentOrElse(platform ->
+                            NativeTarget.of(platform).ifPresentOrElse((target -> {
+                                        record(details, platform.id(), platform.name());
+                                        ctx.redirect(format(prepareRemoteBinaryUrl(), version, version, target.getTriple()));
+                                    }),
+                                    () -> ctx.clientError(404)),
+                    () -> ctx.clientError(404));
+        }, () -> ctx.clientError(400));
+    }
+
+    private String prepareRemoteBinaryUrl() {
+        return config.getProtocol() + "://" + config.getHost() + config.getUri() + config.getName();
+    }
+
+    private void record(RequestDetails details, String platform, String distribution) {
+        auditRepo.record(AuditEntry.of(details.getCommand(), "sdkman_native", details.getVersion(), details.getHost(), details.getAgent(), platform, distribution));
+    }
+}

--- a/src/main/resources/native_binary.properties
+++ b/src/main/resources/native_binary.properties
@@ -1,0 +1,4 @@
+native.protocol = https
+native.host = github.com
+native.uri = /sdkman/sdkman-cli-native/releases/download/v%s/
+native.name = sdkman-cli-native-%s-%s.zip

--- a/src/test/groovy/io/sdkman/broker/binary/BinaryDownloadRequestDetailsSpec.groovy
+++ b/src/test/groovy/io/sdkman/broker/binary/BinaryDownloadRequestDetailsSpec.groovy
@@ -26,7 +26,7 @@ class BinaryDownloadRequestDetailsSpec extends Specification {
         ctx.getRequest() >> request
 
         when:
-        def maybeDetails = BinaryDownloadHandler.RequestDetails.of(ctx)
+        def maybeDetails = RequestDetails.of(ctx)
 
         then:
         maybeDetails.isPresent()
@@ -61,7 +61,7 @@ class BinaryDownloadRequestDetailsSpec extends Specification {
         ctx.getRequest() >> request
 
         when:
-        def maybeDetails = BinaryDownloadHandler.RequestDetails.of(ctx)
+        def maybeDetails = RequestDetails.of(ctx)
 
         then:
         !maybeDetails.isPresent()
@@ -86,7 +86,7 @@ class BinaryDownloadRequestDetailsSpec extends Specification {
         ctx.getRequest() >> request
 
         when:
-        def maybeDetails = BinaryDownloadHandler.RequestDetails.of(ctx)
+        def maybeDetails = RequestDetails.of(ctx)
 
         then:
         !maybeDetails.isPresent()
@@ -111,7 +111,7 @@ class BinaryDownloadRequestDetailsSpec extends Specification {
         ctx.getRequest() >> request
 
         when:
-        def maybeDetails = BinaryDownloadHandler.RequestDetails.of(ctx)
+        def maybeDetails = RequestDetails.of(ctx)
 
         then:
         !maybeDetails.isPresent()


### PR DESCRIPTION
- Depend on latest sdkman-persistence-model v1.1.1 supporting stableNativeCliVersion.
- Move RequestDetails out of BinaryDownloadHandler.
- Make AppRepo aware of stableNativeCliVersion.
- Introduce NativeBinaryDownloadHandler with supporting classes.
- Wire NativeBinaryDownloadHandler and associated config into Main class.
- Add acceptance tests for native sdkman binaries.
- Test scenarios where platform or distribution is not supported.
