### PR TITLE
Write archive type info as header

### DIFF
--- a/src/funtest/features/content_headers.feature
+++ b/src/funtest/features/content_headers.feature
@@ -1,0 +1,14 @@
+Feature: Write content headers when downloading a Candidate
+
+  Scenario: Propagate HTTP header with zip type
+    Given a valid UNIVERSAL binary for groovy 2.4.7 hosted at http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip
+    When a download request is made on "/download/groovy/2.4.7/linuxx64"
+    Then a redirect to "http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip" is returned
+    And a header with archive type "zip" is returned
+
+  Scenario: Propagate HTTP header with tarball type
+    Given a valid MAC_OSX binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg
+    And a valid LINUX_64 binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz
+    When a download request is made on "/download/java/8u101/linuxx64"
+    Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz" is returned
+    And a header with archive type "tar" is returned

--- a/src/funtest/features/download.feature
+++ b/src/funtest/features/download.feature
@@ -82,3 +82,23 @@ Feature: Download a Candidate Version
     When a download request is made on "/download/java/8u101/darwin"
     Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg" is returned
     And a checksum "MAC_OSXaa605037178b63a" for header "X-Sdkman-Checksum-SHA-1" is returned
+
+  Scenario: Download a Universal binary with a zip file
+    Given a valid UNIVERSAL binary for groovy 2.4.7 hosted at http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip
+    When a download request is made on "/download/groovy/2.4.7/linuxx64"
+    Then a redirect to "http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip" is returned
+    And a header with archive type "zip" is returned
+
+  Scenario: Download a Universal binary with a tarball file
+    Given a valid MAC_OSX binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg
+    And a valid LINUX_64 binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz
+    When a download request is made on "/download/java/8u101/linuxx64"
+    Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz" is returned
+    And a header with archive type "tar" is returned
+
+  Scenario: Download a Universal binary with a dmg file
+    Given a valid MAC_OSX binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg
+    And a valid LINUX_64 binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz
+    When a download request is made on "/download/java/8u101/darwin"
+    Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg" is returned
+    And a header with archive type "dmg" is returned

--- a/src/funtest/features/download.feature
+++ b/src/funtest/features/download.feature
@@ -82,23 +82,3 @@ Feature: Download a Candidate Version
     When a download request is made on "/download/java/8u101/darwin"
     Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg" is returned
     And a checksum "MAC_OSXaa605037178b63a" for header "X-Sdkman-Checksum-SHA-1" is returned
-
-  Scenario: Download a Universal binary with a zip file
-    Given a valid UNIVERSAL binary for groovy 2.4.7 hosted at http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip
-    When a download request is made on "/download/groovy/2.4.7/linuxx64"
-    Then a redirect to "http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip" is returned
-    And a header with archive type "zip" is returned
-
-  Scenario: Download a Universal binary with a tarball file
-    Given a valid MAC_OSX binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg
-    And a valid LINUX_64 binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz
-    When a download request is made on "/download/java/8u101/linuxx64"
-    Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz" is returned
-    And a header with archive type "tar" is returned
-
-  Scenario: Download a Universal binary with a dmg file
-    Given a valid MAC_OSX binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg
-    And a valid LINUX_64 binary for java 8u101 hosted at http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz
-    When a download request is made on "/download/java/8u101/darwin"
-    Then a redirect to "http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-macosx-x64.dmg" is returned
-    And a header with archive type "dmg" is returned

--- a/src/funtest/groovy/steps/rest.groovy
+++ b/src/funtest/groovy/steps/rest.groovy
@@ -3,6 +3,7 @@ package steps
 import wslite.rest.RESTClientException
 
 import static io.cucumber.groovy.EN.And
+import static io.sdkman.broker.download.CandidateDownloadHandler.X_SDKMAN_ARCHIVE_TYPE
 
 And(~/^a binary resource for SDKMAN "(.*)" is hosted at "(.*)"$/) { String name, String url ->
     //nothing to do
@@ -45,6 +46,11 @@ And(~/^a redirect to "(.*)" is returned/) { String url ->
 And(~/^a checksum "(.*)" for header "(.*)" is returned/) { String checksum, String checksumHeaderKey ->
     assert response.headers.containsKey(checksumHeaderKey)
     assert response.headers["${checksumHeaderKey}"] == checksum
+}
+
+And(~/^a header with archive type "(.*)" is returned/) { String archiveType ->
+    assert response.headers.containsKey(X_SDKMAN_ARCHIVE_TYPE)
+    assert response.headers[X_SDKMAN_ARCHIVE_TYPE] == archiveType
 }
 
 And(~/^the response is "(.*)"$/) { String txt ->

--- a/src/main/java/io/sdkman/broker/download/ArchiveType.java
+++ b/src/main/java/io/sdkman/broker/download/ArchiveType.java
@@ -7,8 +7,7 @@ import java.util.EnumSet;
  */
 public enum ArchiveType {
     ZIP("zip", "zip"),
-    TAR("tar", "tar.gz"),
-    DMG("dmg", "dmg");
+    TAR("tar", "tar.gz");
 
     private final String type;
     private final String extension;

--- a/src/main/java/io/sdkman/broker/download/ArchiveType.java
+++ b/src/main/java/io/sdkman/broker/download/ArchiveType.java
@@ -1,0 +1,35 @@
+package io.sdkman.broker.download;
+
+import java.util.EnumSet;
+
+/**
+ * Supported archive types to be returned by the {@link CandidateDownloadHandler} controller.
+ */
+public enum ArchiveType {
+    ZIP("zip", "zip"),
+    TAR("tar", "tar.gz"),
+    DMG("dmg", "dmg");
+
+    private final String type;
+    private final String extension;
+
+    public String type() {
+        return type;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    ArchiveType(String type, String extension) {
+        this.type = type;
+        this.extension = extension;
+    }
+
+    public static ArchiveType fromUrl(String url) {
+        return EnumSet.allOf(ArchiveType.class).stream()
+                .filter(archiveType -> url.endsWith(archiveType.extension()))
+                .findFirst()
+                .orElse(ZIP);
+    }
+}

--- a/src/main/java/io/sdkman/broker/download/CandidateDownloadHandler.java
+++ b/src/main/java/io/sdkman/broker/download/CandidateDownloadHandler.java
@@ -31,9 +31,9 @@ import scala.collection.JavaConverters;
 @Singleton
 public class CandidateDownloadHandler implements Handler {
 
+    private static final Logger logger = LoggerFactory.getLogger(CandidateDownloadHandler.class);
     private static final String COMMAND = "install";
     private static final String X_SDK_MAN_CHECKSUM = "X-Sdkman-Checksum";
-    private static final Logger logger = LoggerFactory.getLogger(CandidateDownloadHandler.class);
     private static final Comparator<String> algoComparator =
             Comparator.comparing((Function<String, Integer>) algorithm -> {
                 if (MD5.id().equals(algorithm)) {
@@ -53,6 +53,7 @@ public class CandidateDownloadHandler implements Handler {
                 }
             }).reversed();
 
+    public static final String X_SDKMAN_ARCHIVE_TYPE = "X-Sdkman-ArchiveType";
 
     private final VersionRepo versionRepo;
     private final AuditRepo auditRepo;
@@ -79,6 +80,8 @@ public class CandidateDownloadHandler implements Handler {
                                                         v.checksums().foreach(v1 ->
                                                                 writeChecksumHeaders(ctx, v1));
 
+                                                        ctx.header(X_SDKMAN_ARCHIVE_TYPE,
+                                                                ArchiveType.fromUrl(v.url()).type());
                                                         ctx.redirect(302, v.url());
                                                     }, clientError(ctx, 404))),
                             clientError(ctx, 400));


### PR DESCRIPTION
Add an HTTP header to the response containing the archive type (zip, tar, dmg)
