### PR TITLE
Remove duplicate record audit method

### DIFF
--- a/src/main/java/io/sdkman/broker/audit/AuditEntry.java
+++ b/src/main/java/io/sdkman/broker/audit/AuditEntry.java
@@ -1,5 +1,7 @@
 package io.sdkman.broker.audit;
 
+import io.sdkman.broker.binary.RequestDetails;
+
 public class AuditEntry {
     private final String command;
     private final String candidate;
@@ -69,5 +71,13 @@ public class AuditEntry {
     public static AuditEntry of(String command, String candidate, String version,
                                 String host, String agent, String platform, String dist) {
         return new AuditEntry(command, candidate, version, host, agent, platform, dist);
+    }
+
+    public static AuditEntry of(RequestDetails details, String candidate, String platform, String distribution) {
+        if (details == null) {
+            throw new IllegalArgumentException("details must not be null");
+        }
+
+        return of(details.getCommand(), candidate, details.getVersion(), details.getHost(), details.getAgent(), platform, distribution);
     }
 }

--- a/src/main/java/io/sdkman/broker/audit/AuditRepo.java
+++ b/src/main/java/io/sdkman/broker/audit/AuditRepo.java
@@ -12,16 +12,16 @@ import ratpack.exec.Blocking;
 @Singleton
 public class AuditRepo {
 
-    private final static Logger LOG = LoggerFactory.getLogger(AuditRepo.class);
+    private static final Logger logger = LoggerFactory.getLogger(AuditRepo.class);
 
-    private MongoProvider mongoProvider;
+    private final MongoProvider mongoProvider;
 
     @Inject
     public AuditRepo(MongoProvider mongoProvider) {
         this.mongoProvider = mongoProvider;
     }
 
-    public void record(AuditEntry auditEntry) {
+    public void insertAudit(AuditEntry auditEntry) {
         Blocking.exec(() -> {
                     mongoProvider.database()
                             .getCollection("audit", BasicDBObject.class)
@@ -36,7 +36,7 @@ public class AuditRepo {
                                             .append("platform", auditEntry.getPlatform())
                                             .append("dist", auditEntry.getDist())
                                             .append("timestamp", auditEntry.getTimestamp()));
-                    LOG.debug("Logged: " + auditEntry);
+                    logger.debug("Logged: {}", auditEntry);
                 }
         );
     }

--- a/src/main/java/io/sdkman/broker/db/MongoProvider.java
+++ b/src/main/java/io/sdkman/broker/db/MongoProvider.java
@@ -10,13 +10,12 @@ import com.mongodb.client.MongoDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Singleton
 public class MongoProvider {
 
-    private final static Logger LOG = LoggerFactory.getLogger(MongoProvider.class);
+    private static final Logger logger = LoggerFactory.getLogger(MongoProvider.class);
 
     private final MongoConfig mongoConfig;
     private final MongoClient mongoClient;
@@ -28,7 +27,7 @@ public class MongoProvider {
     }
 
     private MongoClient mongo() {
-        LOG.info("Initialising mongo client.");
+        logger.info("Initialising mongo client.");
         ServerAddress serverAddress = new ServerAddress(mongoConfig.getHost(), mongoConfig.getPort());
         MongoClientOptions clientOptions = MongoClientOptions.builder()
                 .serverSelectionTimeout(mongoConfig.getServerSelectionTimeout())
@@ -40,17 +39,14 @@ public class MongoProvider {
                     mongoConfig.getUsername(),
                     mongoConfig.getDbName(),
                     mongoConfig.getPassword().toCharArray());
-            List<MongoCredential> credentials = new ArrayList<MongoCredential>() {{
-                add(credential);
-            }};
 
-            return new MongoClient(serverAddress, credentials, clientOptions);
-        } else {
-            return new MongoClient(serverAddress, clientOptions);
+            return new MongoClient(serverAddress, List.of(credential), clientOptions);
         }
+
+         return new MongoClient(serverAddress, clientOptions);
     }
 
-    public MongoDatabase database() throws Exception {
+    public MongoDatabase database() {
         return mongoClient.getDatabase(mongoConfig.getDbName());
     }
 }

--- a/src/main/java/io/sdkman/broker/download/CandidateDownloadHandler.java
+++ b/src/main/java/io/sdkman/broker/download/CandidateDownloadHandler.java
@@ -105,7 +105,7 @@ public class CandidateDownloadHandler implements Handler {
     }
 
     private void audit(RequestDetails details, String platform, String dist) {
-        auditRepo.record(
+        auditRepo.insertAudit(
                 AuditEntry.of(
                         COMMAND, details.getCandidate(), details.getVersion(), details.getHost(),
                         details.getAgent(), platform, dist));


### PR DESCRIPTION
Remove some duplicate code, ```NativeBinaryDownloadHandler.record()``` and ```BinaryDownloadHandler.record()```. record is now also a reserved java keyword, so if the Java version is ever increased to >=14 this would be an issue.

Other changes include reorganizing some access modifiers and some formatting. 